### PR TITLE
Remove obsolete and buggy DTB detection

### DIFF
--- a/build/imx6/content-tpl/boot/boot.scr.txt
+++ b/build/imx6/content-tpl/boot/boot.scr.txt
@@ -17,20 +17,6 @@ if test ${debug} != ""; then exit 1; fi
 
 load mmc 0:1 ${loadaddr} zImage
 
-if test ${board} = mx6-cubox-i; then
-    if test ${cpu} = 6SOLO || test ${cpu} = 6DL; then 
-        load mmc 0:1 ${fdt_addr} imx6dl-cubox-i.dtb
-    else 
-        load mmc 0:1 ${fdt_addr} imx6q-cubox-i.dtb
-    fi
-else
-    if test ${cpu} = 6SOLO || test ${cpu} = 6DL; then 
-        load mmc 0:1 ${fdt_addr} imx6dl-hummingboard.dtb
-    else 
-        load mmc 0:1 ${fdt_addr} imx6q-hummingboard.dtb
-    fi
-fi
-
 if load mmc 0:1 0x20000000 initramfs.gz; then
     setenv initram 0x20000000
 else


### PR DESCRIPTION
The latest u-boot automatically detects and picks the right DTB file. Also, the current implementation was buggy. The Hummingboard also identified itself as a mx6-cubox-i, therefor loading one of the two wrong imx6{dl,q}-cubox-i.dtb files.
